### PR TITLE
Avoid `fclose(): supplied resource is not a valid stream resource` on PHP ^8.0

### DIFF
--- a/FilesystemAdapterTestCase.php
+++ b/FilesystemAdapterTestCase.php
@@ -144,7 +144,9 @@ abstract class FilesystemAdapterTestCase extends TestCase
             $writeStream = stream_with_contents('contents');
 
             $adapter->writeStream('path.txt', $writeStream, new Config());
-            fclose($writeStream);
+            if (is_resource($writeStream)) {
+                fclose($writeStream);
+            }
             $fileExists = $adapter->fileExists('path.txt');
 
             $this->assertTrue($fileExists);
@@ -195,7 +197,9 @@ abstract class FilesystemAdapterTestCase extends TestCase
             $writeStream = stream_with_contents('');
 
             $adapter->writeStream('path.txt', $writeStream, new Config());
-            fclose($writeStream);
+            if (is_resource($writeStream)) {
+                fclose($writeStream);
+            }
             $fileExists = $adapter->fileExists('path.txt');
 
             $this->assertTrue($fileExists);


### PR DESCRIPTION
@frankdejonge same as `writing_and_reading_with_streams` test
https://github.com/thephpleague/flysystem-adapter-test-utilities/blob/194699de51c86df119620863b47ce101c1d513bd/FilesystemAdapterTestCase.php#L492-L494
Fix for `stream_with_contents` method